### PR TITLE
Rename dep find function to users(), use UUIDs

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "PkgDeps"
 uuid = "839e9fc8-855b-5b3c-a3b7-2833d3dd1f59"
 license = "MIT"
-version = "0.2.0"
+version = "0.3.0"
 
 [deps]
 Pkg = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"

--- a/src/PkgDeps.jl
+++ b/src/PkgDeps.jl
@@ -5,26 +5,13 @@ using TOML: parsefile
 using UUIDs
 
 export PkgEntry, RegistryInstance
-export find_downstream_dependencies, reachable_registries
+export users, reachable_registries
 
 include("pkg_entry.jl")
 include("registry_instance.jl")
 
+const GENERAL_REGISTRY = "General"
 
-"""
-    _get_latest_version(base_path::AbstractString)
-
-Get the latest VersionNumber for base_path/Versions.toml
-
-# Arguments
-- `base_path::AbstractString`: Base path to look for Versions.toml
-
-# Returns
-- `VersionNumber`: Highest version number found in base_path/Versions.toml
-
-# Throws
-- `VersionTOMLNotFound`: Versions.toml does not exist at the base_path
-"""
 function _get_latest_version(base_path::AbstractString)
     versions_file_path = joinpath(base_path, "Versions.toml")
 
@@ -37,8 +24,42 @@ function _get_latest_version(base_path::AbstractString)
 end
 
 
+function _get_pkg_name(
+    uuid::UUID;
+    kwargs...
+)
+    registries = reachable_registries(; kwargs...)
+
+    for rego in registries
+        for pkg in rego.pkgs
+            if pkg[2].uuid == uuid
+                return pkg[1]
+            end
+        end
+    end
+end
+_get_pkg_name(uuid::String; kwargs...) = _get_pkg_name(UUID(uuid); kwargs...)
+
+
+function _get_pkg_uuid(
+    pkg_name::String, registry_name::String;
+    depots::Union{String, Vector{String}}=Base.DEPOT_PATH,
+    kwargs...
+)
+    registry = reachable_registries(registry_name; depots=depots)
+
+    if haskey(registry.pkgs, pkg_name)
+        return registry.pkgs[pkg_name].uuid
+    else
+        throw(error("$pkg_name not in $registry_name"))
+    end
+end
+
+
 """
     reachable_registries(registry_names::Array)
+    reachable_registries(registry_name::String; depots::Union{String, Vector{String}}=Base.DEPOT_PATH)
+    reachable_registries(; depots::Union{String, Vector{String}}=Base.DEPOT_PATH)
 
 Get an array of found registries.
 
@@ -77,28 +98,30 @@ function reachable_registries(
 
     return registries
 end
+reachable_registries(registry_name::String; depots::Union{String, Vector{String}}=Base.DEPOT_PATH) = first(reachable_registries([registry_name]; depots=depots))
 reachable_registries(; depots::Union{String, Vector{String}}=Base.DEPOT_PATH) = reachable_registries([]; depots=depots)
-reachable_registries(registry_name::String; depots::Union{String, Vector{String}}=Base.DEPOT_PATH) = reachable_registries([registry_name]; depots=depots)
 
 
 """
-    find_downstream_dependencies(pkg_name::AbstractString; registries::Array{PkgDeps.RegistryInstance}=reachable_registries())
+    users(uuid::UUID; registries::Array{RegistryInstance}=reachable_registries())
 
-Find all dependents of `pkg_name` for the current master version.
+Find the users of a given package.
 
 # Arguments
-- `pkg_name::AbstractString`: Name of the package to find dependents
+- `uuid::UUID`: UUID of the package
 
 # Keywords
-- `registries::Array{RegistryInstance}=reachable_registries()`: Registries to look into
+- `registries::Array{RegistryInstance}=reachable_registries()`: Registry to find users in
 
 # Returns
-- `Array{String}`: List of packages which depend on `pkg_name`
+- `Array{String}`: All packages which are dependent on `pkg_name`
 """
-function find_downstream_dependencies(
-    pkg_name::AbstractString;
-    registries::Array{RegistryInstance}=reachable_registries()
+function users(
+    uuid::UUID;
+    registries::Array{RegistryInstance}=reachable_registries(),
+    kwargs...
 )
+    pkg_name = _get_pkg_name(uuid; kwargs...)
     downstream_dependencies = String[]
 
     for rego in registries
@@ -127,6 +150,30 @@ function find_downstream_dependencies(
     end
 
     return downstream_dependencies
+end
+
+
+"""
+    users(pkg_name::String; pkg_registry_name::String=GENERAL_REGISTRY)
+
+Find all packages which use `pkg_name`. Use the `pkg_registry_name` to look up the UUID of `pkg_name`.
+
+# Arguments
+- `pkg_name::String`: Find users of this package
+
+# Keywords
+- `registry_name::String=GENERAL_REGISTRY`: Name of registry where `pkg_name` is active
+
+# Returns
+- `Array{String}`: All packages which are dependent on `pkg_name`
+"""
+function users(
+    pkg_name::String;
+    pkg_registry_name::String=GENERAL_REGISTRY,
+    kwargs...
+)
+    uuid = _get_pkg_uuid(pkg_name, pkg_registry_name; kwargs...)
+    return users(uuid; kwargs...)
 end
 
 end

--- a/src/PkgDeps.jl
+++ b/src/PkgDeps.jl
@@ -24,16 +24,13 @@ function _get_latest_version(base_path::AbstractString)
 end
 
 
-function _get_pkg_name(
-    uuid::UUID;
-    kwargs...
-)
+function _get_pkg_name(uuid::UUID; kwargs...)
     registries = reachable_registries(; kwargs...)
 
     for rego in registries
-        for pkg in rego.pkgs
-            if pkg[2].uuid == uuid
-                return pkg[1]
+        for (pkg_name, pkg_entry) in rego.pkgs
+            if pkg_entry.uuid == uuid
+                return pkg_name
             end
         end
     end

--- a/src/PkgDeps.jl
+++ b/src/PkgDeps.jl
@@ -166,7 +166,7 @@ end
 
 
 """
-    users(pkg_name::String; pkg_registry_name::String=GENERAL_REGISTRY)
+    users(pkg_name::String; pkg_registry_name::String="$GENERAL_REGISTRY")
 
 Find all packages which use `pkg_name`. Use the `pkg_registry_name` to look up the UUID of `pkg_name`.
 
@@ -174,7 +174,7 @@ Find all packages which use `pkg_name`. Use the `pkg_registry_name` to look up t
 - `pkg_name::String`: Find users of this package
 
 # Keywords
-- `registry_name::String=GENERAL_REGISTRY`: Name of registry where `pkg_name` is active
+- `registry_name::String="$GENERAL_REGISTRY"`: Name of registry where `pkg_name` is active
 
 # Returns
 - `Array{String}`: All packages which are dependent on `pkg_name`

--- a/src/exceptions.jl
+++ b/src/exceptions.jl
@@ -1,0 +1,9 @@
+struct PackageNotInRegistry <: Exception
+    message::String
+end
+Base.show(io::IO, e::PackageNotInRegistry) = println(io, e.message)
+
+struct NoUUIDMatch <: Exception
+    message::String
+end
+Base.show(io::IO, e::NoUUIDMatch) = println(io, e.message)

--- a/test/resources/registries/Foobar/Registry.toml
+++ b/test/resources/registries/Foobar/Registry.toml
@@ -6,3 +6,4 @@ description = "Fake private package registry."
 [packages]
 00000000-1111-2222-3333-444444444444 = { name = "Case1", path = "Case1" }
 000eeb74-f857-587a-a816-be5685e97e75 = { name = "Case2", path = "Case2" }
+d5005c69-b073-4eb3-8b36-d4bd8a43d538 = { name = "DownDep", path = "DownDep" }

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,8 +1,33 @@
 using PkgDeps
 using Test
+using UUIDs
 
 depot = joinpath(@__DIR__, "resources")
 
+
+@testset "internal functions" begin
+    @testset "_get_pkg_name" begin
+        expected = "Case1"
+        pkg_name = PkgDeps._get_pkg_name(UUID("00000000-1111-2222-3333-444444444444"); depots=depot)
+
+        @test expected == pkg_name
+    end
+
+    @testset "_get_pkg_uuid" begin
+        expected = UUID("00000000-1111-2222-3333-444444444444")
+        pkg_uuid = PkgDeps._get_pkg_uuid("Case1", "Foobar"; depots=depot)
+
+        @test expected == pkg_uuid
+    end
+
+    @testset "_get_latest_version" begin
+        expected = v"0.2.0"
+        path = joinpath("resources", "registries", "General", "Case4")
+        result = PkgDeps._get_latest_version(path)
+
+        @test expected == result
+    end
+end
 
 @testset "reachable_registries" begin
     @testset "specfic registry -- $(typeof(v))" for v in ("Foobar", ["Foobar"])

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -7,17 +7,29 @@ depot = joinpath(@__DIR__, "resources")
 
 @testset "internal functions" begin
     @testset "_get_pkg_name" begin
-        expected = "Case1"
-        pkg_name = PkgDeps._get_pkg_name(UUID("00000000-1111-2222-3333-444444444444"); depots=depot)
+        @testset "uuid to name" begin
+            expected = "Case1"
+            pkg_name = PkgDeps._get_pkg_name(UUID("00000000-1111-2222-3333-444444444444"); depots=depot)
 
-        @test expected == pkg_name
+            @test expected == pkg_name
+        end
+
+        @testset "exception" begin
+            @test_throws NoUUIDMatch PkgDeps._get_pkg_name(UUID("00000000-0000-0000-0000-000000000000"); depots=depot)
+        end
     end
 
     @testset "_get_pkg_uuid" begin
-        expected = UUID("00000000-1111-2222-3333-444444444444")
-        pkg_uuid = PkgDeps._get_pkg_uuid("Case1", "Foobar"; depots=depot)
+        @testset "name to uuid" begin
+            expected = UUID("00000000-1111-2222-3333-444444444444")
+            pkg_uuid = PkgDeps._get_pkg_uuid("Case1", "Foobar"; depots=depot)
 
-        @test expected == pkg_uuid
+            @test expected == pkg_uuid
+        end
+
+        @testset "exception" begin
+            @test_throws PackageNotInRegistry PkgDeps._get_pkg_uuid("FakePackage", "Foobar"; depots=depot)
+        end
     end
 
     @testset "_get_latest_version" begin

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -3,12 +3,12 @@ using Test
 
 depot = joinpath(@__DIR__, "resources")
 
+
 @testset "reachable_registries" begin
     @testset "specfic registry -- $(typeof(v))" for v in ("Foobar", ["Foobar"])
-        registries = reachable_registries("Foobar"; depots=depot)
+        registry = reachable_registries("Foobar"; depots=depot)
 
-        @test length(registries) == 1
-        @test registries[1].name == "Foobar"
+        @test registry.name == "Foobar"
     end
 
     @testset "all registries" begin
@@ -18,19 +18,19 @@ depot = joinpath(@__DIR__, "resources")
     end
 end
 
-@testset "find_downstream_dependencies" begin
+@testset "users" begin
     foobar_registry = reachable_registries("Foobar"; depots=depot)
     all_registries = reachable_registries(; depots=depot)
 
     @testset "specific registry" begin
-        dependents = find_downstream_dependencies("DownDep"; registries=foobar_registry)
+        dependents = users("DownDep"; pkg_registry_name="Foobar", depots=depot, registries=[foobar_registry])
 
         @test length(dependents) == 2
         [@test case in dependents for case in ["Case1", "Case2"]]
     end
 
     @testset "all registries" begin
-        dependents = find_downstream_dependencies("DownDep"; registries=all_registries)
+        dependents = users("DownDep"; pkg_registry_name="Foobar", depots=depot, registries=all_registries)
 
         @test length(dependents) == 3
         @test !("Case4" in dependents)


### PR DESCRIPTION
## Resolves #12, #17 

- Instead of `find_downstream_dependencies()` move to a better name of `users()`
- Use `UUIDs` when searching for packages to remove ambiguity, still can use the packages name, but need to specify the registry which it's in (default to General)

TODO:
- [x] Add tests for `_get_uuid()` and `_get_name()`
- [x] Add tests for searching by `UUID`