### PR TITLE
Don't thread `kwargs` threw various functions; Remove `depot` keyword from `users` and allow passing a `RegistryInstance`

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "PkgDeps"
 uuid = "839e9fc8-855b-5b3c-a3b7-2833d3dd1f59"
 license = "MIT"
-version = "0.3.0"
+version = "0.4.0"
 
 [deps]
 Pkg = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"

--- a/src/PkgDeps.jl
+++ b/src/PkgDeps.jl
@@ -115,18 +115,22 @@ reachable_registries(; depots::Union{String, Vector{String}}=Base.DEPOT_PATH) = 
 
 
 """
-    users(uuid::UUID; registries=reachable_registries())
+    users(uuid::UUID; kwargs...)
+    users(pkg_name::String, pkg_registry_name::String="$GENERAL_REGISTRY"; kwargs...)
 
 Find the users of a given package.
 
 # Arguments
 - `uuid::UUID`: UUID of the package.
+- `pkg_name::String`: Find users of this package.
+- `pkg_registry_name::String="$GENERAL_REGISTRY"`: Name of registry where `pkg_name` is
+  registered. This is used to look up the UUID of `pkg_name`.
 
 # Keywords
 - `registries::Array{RegistryInstance}=reachable_registries()`: Registries to search for users.
 
 # Returns
-- `Array{String}`: All packages which are dependent on `pkg_name`.
+- `Array{String}`: All packages which are dependent on the given package.
 """
 function users(
     uuid::UUID;
@@ -164,32 +168,9 @@ function users(
     return downstream_dependencies
 end
 
-
-"""
-    users(pkg_name::String; pkg_registry_name="$GENERAL_REGISTRY", registries=reachable_registries())
-
-Find all packages which use `pkg_name`.
-
-The `pkg_registry_name` should be the name of the registry where `pkg_name` is registered.
-This is used to look up the UUID of `pkg_name`.
-
-# Arguments
-- `pkg_name::String`: Find users of this package.
-
-# Keywords
-- `pkg_registry_name::String="$GENERAL_REGISTRY"`: Name of registry where `pkg_name` is registered.
-- `registries::Array{RegistryInstance}=reachable_registries()`: Registries to search for users.
-
-# Returns
-- `Array{String}`: All packages which are dependent on `pkg_name`.
-"""
-function users(
-    pkg_name::String;
-    pkg_registry_name::String=GENERAL_REGISTRY,
-    kwargs...
-)
+function users(pkg_name::String, pkg_registry_name::String=GENERAL_REGISTRY; kwargs...)
     uuid = _get_pkg_uuid(pkg_name, pkg_registry_name; kwargs...)
     return users(uuid; kwargs...)
 end
 
-end
+end  # module

--- a/src/PkgDeps.jl
+++ b/src/PkgDeps.jl
@@ -170,6 +170,11 @@ function users(pkg_name::String, pkg_registry_name::String=GENERAL_REGISTRY; kwa
 end
 
 # Useful for testing using with registries not in `DEPOT_PATH`.
+"""
+    users(pkg_name::String, pkg_registry::RegistryInstance; kwargs...)
+
+Find the users of the package named `pkg_name` which is registered in `pkg_registry`.
+"""
 function users(pkg_name::String, pkg_registry::RegistryInstance; kwargs...)
     uuid = _get_pkg_uuid(pkg_name, pkg_registry)
     return users(uuid; kwargs...)

--- a/src/PkgDeps.jl
+++ b/src/PkgDeps.jl
@@ -50,7 +50,7 @@ _get_pkg_name(uuid::String; kwargs...) = _get_pkg_name(UUID(uuid); kwargs...)
 
 
 """
-Get the UUID from a package name and the registry its in.
+Get the UUID from a package name and the registry it is in.
 Specify a registry name as well to avoid ambiguity with same package names in multiple registries.
 """
 function _get_pkg_uuid(
@@ -115,18 +115,18 @@ reachable_registries(; depots::Union{String, Vector{String}}=Base.DEPOT_PATH) = 
 
 
 """
-    users(uuid::UUID; registries::Array{RegistryInstance}=reachable_registries())
+    users(uuid::UUID; registries=reachable_registries())
 
 Find the users of a given package.
 
 # Arguments
-- `uuid::UUID`: UUID of the package
+- `uuid::UUID`: UUID of the package.
 
 # Keywords
-- `registries::Array{RegistryInstance}=reachable_registries()`: Registry to find users in
+- `registries::Array{RegistryInstance}=reachable_registries()`: Registries to search for users.
 
 # Returns
-- `Array{String}`: All packages which are dependent on `pkg_name`
+- `Array{String}`: All packages which are dependent on `pkg_name`.
 """
 function users(
     uuid::UUID;
@@ -166,18 +166,22 @@ end
 
 
 """
-    users(pkg_name::String; pkg_registry_name::String="$GENERAL_REGISTRY")
+    users(pkg_name::String; pkg_registry_name="$GENERAL_REGISTRY", registries=reachable_registries())
 
-Find all packages which use `pkg_name`. Use the `pkg_registry_name` to look up the UUID of `pkg_name`.
+Find all packages which use `pkg_name`.
+
+The `pkg_registry_name` should be the name of the registry where `pkg_name` is registered.
+This is use to look up the UUID of `pkg_name`.
 
 # Arguments
-- `pkg_name::String`: Find users of this package
+- `pkg_name::String`: Find users of this package.
 
 # Keywords
-- `registry_name::String="$GENERAL_REGISTRY"`: Name of registry where `pkg_name` is active
+- `pkg_registry_name::String="$GENERAL_REGISTRY"`: Name of registry where `pkg_name` is registered.
+- `registries::Array{RegistryInstance}=reachable_registries()`: Registries to search for users.
 
 # Returns
-- `Array{String}`: All packages which are dependent on `pkg_name`
+- `Array{String}`: All packages which are dependent on `pkg_name`.
 """
 function users(
     pkg_name::String;

--- a/src/PkgDeps.jl
+++ b/src/PkgDeps.jl
@@ -171,7 +171,7 @@ end
 Find all packages which use `pkg_name`.
 
 The `pkg_registry_name` should be the name of the registry where `pkg_name` is registered.
-This is use to look up the UUID of `pkg_name`.
+This is used to look up the UUID of `pkg_name`.
 
 # Arguments
 - `pkg_name::String`: Find users of this package.

--- a/src/PkgDeps.jl
+++ b/src/PkgDeps.jl
@@ -132,12 +132,8 @@ Find the users of a given package.
 # Returns
 - `Array{String}`: All packages which are dependent on the given package.
 """
-function users(
-    uuid::UUID;
-    registries::Array{RegistryInstance}=reachable_registries(),
-    kwargs...
-)
-    pkg_name = _get_pkg_name(uuid; kwargs...)
+function users(uuid::UUID; registries::Array{RegistryInstance}=reachable_registries())
+    pkg_name = _get_pkg_name(uuid)
     downstream_dependencies = String[]
 
     for rego in registries
@@ -169,7 +165,7 @@ function users(
 end
 
 function users(pkg_name::String, pkg_registry_name::String=GENERAL_REGISTRY; kwargs...)
-    uuid = _get_pkg_uuid(pkg_name, pkg_registry_name; kwargs...)
+    uuid = _get_pkg_uuid(pkg_name, pkg_registry_name)
     return users(uuid; kwargs...)
 end
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -60,14 +60,14 @@ end
     all_registries = reachable_registries(; depots=depot)
 
     @testset "specific registry" begin
-        dependents = users("DownDep"; pkg_registry_name="Foobar", depots=depot, registries=[foobar_registry])
+        dependents = users("DownDep", "Foobar"; depots=depot, registries=[foobar_registry])
 
         @test length(dependents) == 2
         [@test case in dependents for case in ["Case1", "Case2"]]
     end
 
     @testset "all registries" begin
-        dependents = users("DownDep"; pkg_registry_name="Foobar", depots=depot, registries=all_registries)
+        dependents = users("DownDep", "Foobar"; depots=depot, registries=all_registries)
 
         @test length(dependents) == 3
         @test !("Case4" in dependents)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -2,33 +2,38 @@ using PkgDeps
 using Test
 using UUIDs
 
-depot = joinpath(@__DIR__, "resources")
+const DEPOT = joinpath(@__DIR__, "resources")
+const FOOBAR_REGISTRY = reachable_registries("Foobar"; depots=DEPOT)
 
 
 @testset "internal functions" begin
     @testset "_get_pkg_name" begin
         @testset "uuid to name" begin
             expected = "Case1"
-            pkg_name = PkgDeps._get_pkg_name(UUID("00000000-1111-2222-3333-444444444444"); depots=depot)
+            pkg_name = PkgDeps._get_pkg_name(UUID("00000000-1111-2222-3333-444444444444"); registries=[FOOBAR_REGISTRY])
 
             @test expected == pkg_name
         end
 
         @testset "exception" begin
-            @test_throws NoUUIDMatch PkgDeps._get_pkg_name(UUID("00000000-0000-0000-0000-000000000000"); depots=depot)
+            @test_throws NoUUIDMatch PkgDeps._get_pkg_name(UUID("00000000-0000-0000-0000-000000000000"); registries=[FOOBAR_REGISTRY])
         end
     end
 
     @testset "_get_pkg_uuid" begin
         @testset "name to uuid" begin
             expected = UUID("00000000-1111-2222-3333-444444444444")
-            pkg_uuid = PkgDeps._get_pkg_uuid("Case1", "Foobar"; depots=depot)
 
+            pkg_uuid = PkgDeps._get_pkg_uuid("Case1", "Foobar"; depots=DEPOT)
+            @test expected == pkg_uuid
+
+            pkg_uuid = PkgDeps._get_pkg_uuid("Case1", FOOBAR_REGISTRY)
             @test expected == pkg_uuid
         end
 
         @testset "exception" begin
-            @test_throws PackageNotInRegistry PkgDeps._get_pkg_uuid("FakePackage", "Foobar"; depots=depot)
+            @test_throws PackageNotInRegistry PkgDeps._get_pkg_uuid("PkgDepsFakePackage", "General")
+            @test_throws PackageNotInRegistry PkgDeps._get_pkg_uuid("FakePackage", FOOBAR_REGISTRY)
         end
     end
 
@@ -43,31 +48,30 @@ end
 
 @testset "reachable_registries" begin
     @testset "specfic registry -- $(typeof(v))" for v in ("Foobar", ["Foobar"])
-        registry = reachable_registries("Foobar"; depots=depot)
+        registry = reachable_registries("Foobar"; depots=DEPOT)
 
         @test registry.name == "Foobar"
     end
 
     @testset "all registries" begin
-        registries = reachable_registries(; depots=depot)
+        registries = reachable_registries(; depots=DEPOT)
 
         @test length(registries) == 2
     end
 end
 
 @testset "users" begin
-    foobar_registry = reachable_registries("Foobar"; depots=depot)
-    all_registries = reachable_registries(; depots=depot)
+    all_registries = reachable_registries(; depots=DEPOT)
 
     @testset "specific registry" begin
-        dependents = users("DownDep", "Foobar"; registries=[foobar_registry])
+        dependents = users("DownDep", FOOBAR_REGISTRY; registries=[FOOBAR_REGISTRY])
 
         @test length(dependents) == 2
         [@test case in dependents for case in ["Case1", "Case2"]]
     end
 
     @testset "all registries" begin
-        dependents = users("DownDep", "Foobar"; registries=all_registries)
+        dependents = users("DownDep", FOOBAR_REGISTRY; registries=all_registries)
 
         @test length(dependents) == 3
         @test !("Case4" in dependents)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -60,14 +60,14 @@ end
     all_registries = reachable_registries(; depots=depot)
 
     @testset "specific registry" begin
-        dependents = users("DownDep", "Foobar"; depots=depot, registries=[foobar_registry])
+        dependents = users("DownDep", "Foobar"; registries=[foobar_registry])
 
         @test length(dependents) == 2
         [@test case in dependents for case in ["Case1", "Case2"]]
     end
 
     @testset "all registries" begin
-        dependents = users("DownDep", "Foobar"; depots=depot, registries=all_registries)
+        dependents = users("DownDep", "Foobar"; registries=all_registries)
 
         @test length(dependents) == 3
         @test !("Case4" in dependents)


### PR DESCRIPTION
Based on #20 

Previously the code was threading `kwargs...` threw to many functions.
And in particular this meant there was an undocumented `depot` keyword for `users` which was also ambiguous in my opinion, since it wasn't clear what it applied to.

Prevously you could call `users("DownDep"; pkg_registry_name="Foobar", depots=depot, registries=[foobar_registry])` and it was not at all clear to me that this meant "Look for the package named `"DownDep"` in the registry named `Foobar` where you should look for `"Foobar"` in `depot`, and then tell me all the users in across `registries`".

With this PR the same call is instead `users("DownDep", foobar_registry; registries=[foobar_registry])`, which is "Look for the package named `"DownDep"` in `foobar_registry`, and then tell me all the users in across `registries`".