### PR TITLE
Use levenshtein distance to find alt packages

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -11,7 +11,7 @@ UUIDs = "cf7118a7-6976-5b1a-9a39-7adc72f591a4"
 
 [compat]
 TOML = "1.0"
-julia = "1.5, 1.6"
+julia = "1.5"
 
 [extras]
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"

--- a/Project.toml
+++ b/Project.toml
@@ -11,7 +11,7 @@ UUIDs = "cf7118a7-6976-5b1a-9a39-7adc72f591a4"
 
 [compat]
 TOML = "1.0"
-julia = "1.6"
+julia = "1.5, 1.6"
 
 [extras]
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"

--- a/Project.toml
+++ b/Project.toml
@@ -11,7 +11,7 @@ UUIDs = "cf7118a7-6976-5b1a-9a39-7adc72f591a4"
 
 [compat]
 TOML = "1.0"
-julia = "1"
+julia = "1.6"
 
 [extras]
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"

--- a/Project.toml
+++ b/Project.toml
@@ -5,6 +5,7 @@ version = "0.4.0"
 
 [deps]
 Pkg = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
+REPL = "3fa0cd96-eef1-5676-8a61-b3b8758bbffb"
 TOML = "fa267f1f-6049-4f14-aa54-33bafae1ed76"
 UUIDs = "cf7118a7-6976-5b1a-9a39-7adc72f591a4"
 

--- a/src/PkgDeps.jl
+++ b/src/PkgDeps.jl
@@ -35,7 +35,8 @@ Get an array of found registries.
 """
 function reachable_registries(
     registry_names::Array;
-    depots::Union{String, Vector{String}}=Base.DEPOT_PATH
+    depots::Union{String, Vector{String}}=Base.DEPOT_PATH,
+    kwargs...
 )
     registries = RegistryInstance[]
 
@@ -59,8 +60,8 @@ function reachable_registries(
 
     return registries
 end
-reachable_registries(registry_name::String; depots::Union{String, Vector{String}}=Base.DEPOT_PATH) = first(reachable_registries([registry_name]; depots=depots))
-reachable_registries(; depots::Union{String, Vector{String}}=Base.DEPOT_PATH) = reachable_registries([]; depots=depots)
+reachable_registries(registry_name::String; depots::Union{String, Vector{String}}=Base.DEPOT_PATH, kwargs...) = reachable_registries([registry_name]; depots=depots, kwargs...)
+reachable_registries(; depots::Union{String, Vector{String}}=Base.DEPOT_PATH, kwargs...) = reachable_registries([]; depots=depots, kwargs...)
 
 
 """
@@ -82,7 +83,7 @@ Find the users of a given package.
 - `Array{String}`: All packages which are dependent on the given package.
 """
 function users(uuid::UUID; registries::Array{RegistryInstance}=reachable_registries())
-    pkg_name = _get_pkg_name(uuid; registries=registries)
+    pkg_name = _get_pkg_name(uuid, registries)
     downstream_dependencies = String[]
 
     for rego in registries
@@ -122,10 +123,11 @@ end
 """
     users(pkg_name::String, pkg_registry::RegistryInstance; kwargs...)
 
-Find the users of the package named `pkg_name` which is registered in `pkg_registry`.
+Find the users of `pkg_name` which is registered in `pkg_registry_name`.
+Optionally limit search for users of `pkg_name` in specific registries by passing in kwarg `registries`.
 """
-function users(pkg_name::String, pkg_registry::RegistryInstance; kwargs...)
-    uuid = _get_pkg_uuid(pkg_name, pkg_registry)
+function users(pkg_name::String, pkg_registry_name::RegistryInstance; kwargs...)
+    uuid = _get_pkg_uuid(pkg_name, pkg_registry_name)
     return users(uuid; kwargs...)
 end
 

--- a/src/PkgDeps.jl
+++ b/src/PkgDeps.jl
@@ -123,11 +123,10 @@ end
 """
     users(pkg_name::String, pkg_registry::RegistryInstance; kwargs...)
 
-Find the users of `pkg_name` which is registered in `pkg_registry_name`.
-Optionally limit search for users of `pkg_name` in specific registries by passing in kwarg `registries`.
+Find the users of `pkg_name` which is registered in `pkg_registry`.
 """
-function users(pkg_name::String, pkg_registry_name::RegistryInstance; kwargs...)
-    uuid = _get_pkg_uuid(pkg_name, pkg_registry_name)
+function users(pkg_name::String, pkg_registry::RegistryInstance; kwargs...)
+    uuid = _get_pkg_uuid(pkg_name, pkg_registry)
     return users(uuid; kwargs...)
 end
 

--- a/src/PkgDeps.jl
+++ b/src/PkgDeps.jl
@@ -65,8 +65,9 @@ reachable_registries(; depots::Union{String, Vector{String}}=Base.DEPOT_PATH, kw
 
 
 """
-    users(uuid::UUID; kwargs...)
-    users(pkg_name::String, pkg_registry_name::String="$GENERAL_REGISTRY"; kwargs...)
+    users(uuid::UUID; registries::Array{RegistryInstance}=reachable_registries(), depots::Union{String, Vector{String}}=Base.DEPOT_PATH)
+    users(pkg_name::String, pkg_registry_name::String=GENERAL_REGISTRY; kwargs...)
+    users(pkg_name::String, pkg_registry::RegistryInstance; kwargs...))
 
 Find the users of a given package.
 

--- a/src/PkgDeps.jl
+++ b/src/PkgDeps.jl
@@ -82,8 +82,12 @@ Find the users of a given package.
 # Returns
 - `Array{String}`: All packages which are dependent on the given package.
 """
-function users(uuid::UUID; registries::Array{RegistryInstance}=reachable_registries())
-    pkg_name = _get_pkg_name(uuid, registries)
+function users(
+    uuid::UUID;
+    registries::Array{RegistryInstance}=reachable_registries(),
+    depots::Union{String, Vector{String}}=Base.DEPOT_PATH
+)
+    pkg_name = _get_pkg_name(uuid, reachable_registries(; depots=depots))
     downstream_dependencies = String[]
 
     for rego in registries
@@ -119,12 +123,6 @@ function users(pkg_name::String, pkg_registry_name::String=GENERAL_REGISTRY; kwa
     return users(uuid; kwargs...)
 end
 
-# Useful for testing using with registries not in `DEPOT_PATH`.
-"""
-    users(pkg_name::String, pkg_registry::RegistryInstance; kwargs...)
-
-Find the users of `pkg_name` which is registered in `pkg_registry`.
-"""
 function users(pkg_name::String, pkg_registry::RegistryInstance; kwargs...)
     uuid = _get_pkg_uuid(pkg_name, pkg_registry)
     return users(uuid; kwargs...)

--- a/src/utilities.jl
+++ b/src/utilities.jl
@@ -31,7 +31,7 @@ end
 Get the package name from a UUID
 """
 
-function _get_pkg_name(uuid::UUID, registries=Array{RegistryInstance})
+function _get_pkg_name(uuid::UUID, registries=RegistryInstance[])
     for rego in registries
         for (pkg_name, pkg_entry) in rego.pkgs
             if pkg_entry.uuid == uuid
@@ -57,8 +57,8 @@ function _get_pkg_uuid(
     pkg_name::String, registry_name::String;
     depots::Union{String, Vector{String}}=Base.DEPOT_PATH,
 )
-    registry = reachable_registries(registry_name; depots=depots)
-    return _get_pkg_uuid(pkg_name, first(registry))
+    registry = only(reachable_registries(registry_name; depots=depots))
+    return _get_pkg_uuid(pkg_name, registry)
 end
 
 function _get_pkg_uuid(pkg_name::String, registry::RegistryInstance)
@@ -73,7 +73,7 @@ function _get_pkg_uuid(pkg_name::String, registry::RegistryInstance)
             warning *= "\nPerhaps you meant: $(string(alt_packages))"
         end
 
-        warning *= "\nOr you can search in another registry using `users(\"$(pkg_name)\"; pkg_registry_name=\"OtherRegistry\")`"
+        warning *= "\nOr you can search in another registry using `users(\"$(pkg_name)\", \"OtherRegistry\")`"
         throw(PackageNotInRegistry(warning))
     end
 end

--- a/src/utilities.jl
+++ b/src/utilities.jl
@@ -27,11 +27,11 @@ function _find_alternative_packages(pkg_to_compare::String, packages::Array)
 end
 
 
-
 """
 Get the package name from a UUID
 """
-function _get_pkg_name(uuid::UUID; registries=reachable_registries())
+
+function _get_pkg_name(uuid::UUID, registries=Array{RegistryInstance})
     for rego in registries
         for (pkg_name, pkg_entry) in rego.pkgs
             if pkg_entry.uuid == uuid
@@ -42,7 +42,11 @@ function _get_pkg_name(uuid::UUID; registries=reachable_registries())
 
     throw(NoUUIDMatch("No package found with the UUID $uuid"))
 end
-_get_pkg_name(uuid::String; kwargs...) = _get_pkg_name(UUID(uuid); kwargs...)
+
+function _get_pkg_name(uuid::UUID; kwargs...)
+    registries = reachable_registries(; kwargs...)
+    return _get_pkg_name(uuid, registries)
+end
 
 
 """
@@ -54,7 +58,7 @@ function _get_pkg_uuid(
     depots::Union{String, Vector{String}}=Base.DEPOT_PATH,
 )
     registry = reachable_registries(registry_name; depots=depots)
-    return _get_pkg_uuid(pkg_name, registry)
+    return _get_pkg_uuid(pkg_name, first(registry))
 end
 
 function _get_pkg_uuid(pkg_name::String, registry::RegistryInstance)

--- a/src/utilities.jl
+++ b/src/utilities.jl
@@ -15,15 +15,19 @@ end
 
 """
 Use levenshtein distance to find packages closely named to pkg_to_compare
+
+Rules:
+- Ignore package name casings
+- Only return matches that are between 1 and 2 distances
 """
 function _find_alternative_packages(pkg_to_compare::String, packages::Array)
+    MIN_LEVENSHTEIN = 1
+    MAX_LEVENSHTEIN = 2
+
     pkg_to_compare = uppercase(pkg_to_compare)
     pkg_distances = [(REPL.levenshtein(uppercase(pkg), pkg_to_compare), pkg) for pkg in packages]
-    sort!(pkg_distances)
-    counts = [count(x -> x[1] <= i, pkg_distances) for i in 0:2]
-    max_distance = max(0, searchsortedlast(counts, 8) - 1)
 
-    return [pkg for (distance, pkg) in pkg_distances if distance <= max_distance]
+    return [x[2] for x in pkg_distances if MIN_LEVENSHTEIN <= x[1] <= MAX_LEVENSHTEIN]
 end
 
 

--- a/src/utilities.jl
+++ b/src/utilities.jl
@@ -1,0 +1,75 @@
+"""
+Get the latest VersionNumber for base_path/Versions.toml
+"""
+function _get_latest_version(base_path::AbstractString)
+    versions_file_path = joinpath(base_path, "Versions.toml")
+
+    if isfile(versions_file_path)
+        versions_content = parsefile(versions_file_path)
+        versions = [VersionNumber(v) for v in collect(keys(versions_content))]
+
+        return first(findmax(versions))
+    end
+end
+
+
+"""
+Use levenshtein distance to find packages closely named to pkg_to_compare
+"""
+function _find_alternative_packages(pkg_to_compare::String, packages::Array)
+    pkg_to_compare = uppercase(pkg_to_compare)
+    pkg_distances = [(REPL.levenshtein(uppercase(pkg), pkg_to_compare), pkg) for pkg in packages]
+    sort!(pkg_distances)
+    counts = [count(x -> x[1] <= i, pkg_distances) for i in 0:2]
+    max_distance = max(0, searchsortedlast(counts, 8) - 1)
+
+    return [pkg for (distance, pkg) in pkg_distances if distance <= max_distance]
+end
+
+
+
+"""
+Get the package name from a UUID
+"""
+function _get_pkg_name(uuid::UUID; registries=reachable_registries())
+    for rego in registries
+        for (pkg_name, pkg_entry) in rego.pkgs
+            if pkg_entry.uuid == uuid
+                return pkg_name
+            end
+        end
+    end
+
+    throw(NoUUIDMatch("No package found with the UUID $uuid"))
+end
+_get_pkg_name(uuid::String; kwargs...) = _get_pkg_name(UUID(uuid); kwargs...)
+
+
+"""
+Get the UUID from a package name and the registry it is in.
+Specify a registry name as well to avoid ambiguity with same package names in multiple registries.
+"""
+function _get_pkg_uuid(
+    pkg_name::String, registry_name::String;
+    depots::Union{String, Vector{String}}=Base.DEPOT_PATH,
+)
+    registry = reachable_registries(registry_name; depots=depots)
+    return _get_pkg_uuid(pkg_name, registry)
+end
+
+function _get_pkg_uuid(pkg_name::String, registry::RegistryInstance)
+    if haskey(registry.pkgs, pkg_name)
+        return registry.pkgs[pkg_name].uuid
+    else
+        alt_packages = _find_alternative_packages(pkg_name, collect(keys(registry.pkgs)))
+
+        warning = "The package $(pkg_name) was not found in the $(registry.name) registry."
+
+        if !isempty(alt_packages)
+            warning *= "\nPerhaps you meant: $(string(alt_packages))"
+        end
+
+        warning *= "\nOr you can search in another registry using `users(\"$(pkg_name)\"; pkg_registry_name=\"OtherRegistry\")`"
+        throw(PackageNotInRegistry(warning))
+    end
+end

--- a/test/resources/registries/General/Case4/Deps.toml
+++ b/test/resources/registries/General/Case4/Deps.toml
@@ -1,2 +1,2 @@
 ["0-0.1"]
-DownDep = "000eeb74-f857-587a-a816-be5685e97e75"
+DownDep = "d5005c69-b073-4eb3-8b36-d4bd8a43d538"

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -45,6 +45,15 @@ const FOOBAR_REGISTRY = only(reachable_registries("Foobar"; depots=DEPOT))
 
         @test expected == result
     end
+
+    @testset "_find_alternative_packages" begin
+        MAX = 9
+        pkg_to_compare = "package_name"
+        packages = ["$(pkg_to_compare)_$(i)" for i in 1:MAX]
+
+        result = PkgDeps._find_alternative_packages(pkg_to_compare, packages)
+        @test length(result) == MAX
+    end
 end
 
 @testset "reachable_registries" begin

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -3,6 +3,7 @@ using Test
 using UUIDs
 
 const DEPOT = joinpath(@__DIR__, "resources")
+const GENERAL_REGISTRY = only(reachable_registries("General"; depots=DEPOT))
 const FOOBAR_REGISTRY = only(reachable_registries("Foobar"; depots=DEPOT))
 
 
@@ -63,15 +64,15 @@ end
 @testset "users" begin
     all_registries = reachable_registries(; depots=DEPOT)
 
-    @testset "specific registry" begin
-        dependents = users("DownDep", FOOBAR_REGISTRY; registries=[FOOBAR_REGISTRY])
+    @testset "specific registry - registered in another registry" begin
+        dependents = users("DownDep", FOOBAR_REGISTRY; registries=[GENERAL_REGISTRY], depots=DEPOT)
 
-        @test length(dependents) == 2
-        [@test case in dependents for case in ["Case1", "Case2"]]
+        @test length(dependents) == 1
+        [@test case in dependents for case in ["Case3"]]
     end
 
     @testset "all registries" begin
-        dependents = users("DownDep", FOOBAR_REGISTRY; registries=all_registries)
+        dependents = users("DownDep", FOOBAR_REGISTRY; registries=all_registries, depots=DEPOT)
 
         @test length(dependents) == 3
         @test !("Case4" in dependents)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -3,7 +3,7 @@ using Test
 using UUIDs
 
 const DEPOT = joinpath(@__DIR__, "resources")
-const FOOBAR_REGISTRY = first(reachable_registries("Foobar"; depots=DEPOT))
+const FOOBAR_REGISTRY = only(reachable_registries("Foobar"; depots=DEPOT))
 
 
 @testset "internal functions" begin
@@ -48,7 +48,7 @@ end
 
 @testset "reachable_registries" begin
     @testset "specfic registry -- $(typeof(v))" for v in ("Foobar", ["Foobar"])
-        registry = first(reachable_registries("Foobar"; depots=DEPOT))
+        registry = only(reachable_registries("Foobar"; depots=DEPOT))
 
         @test registry.name == "Foobar"
     end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -3,20 +3,20 @@ using Test
 using UUIDs
 
 const DEPOT = joinpath(@__DIR__, "resources")
-const FOOBAR_REGISTRY = reachable_registries("Foobar"; depots=DEPOT)
+const FOOBAR_REGISTRY = first(reachable_registries("Foobar"; depots=DEPOT))
 
 
 @testset "internal functions" begin
     @testset "_get_pkg_name" begin
         @testset "uuid to name" begin
             expected = "Case1"
-            pkg_name = PkgDeps._get_pkg_name(UUID("00000000-1111-2222-3333-444444444444"); registries=[FOOBAR_REGISTRY])
+            pkg_name = PkgDeps._get_pkg_name(UUID("00000000-1111-2222-3333-444444444444"); depots=DEPOT)
 
             @test expected == pkg_name
         end
 
         @testset "exception" begin
-            @test_throws NoUUIDMatch PkgDeps._get_pkg_name(UUID("00000000-0000-0000-0000-000000000000"); registries=[FOOBAR_REGISTRY])
+            @test_throws NoUUIDMatch PkgDeps._get_pkg_name(UUID("00000000-0000-0000-0000-000000000000"); registries=FOOBAR_REGISTRY)
         end
     end
 
@@ -48,7 +48,7 @@ end
 
 @testset "reachable_registries" begin
     @testset "specfic registry -- $(typeof(v))" for v in ("Foobar", ["Foobar"])
-        registry = reachable_registries("Foobar"; depots=DEPOT)
+        registry = first(reachable_registries("Foobar"; depots=DEPOT))
 
         @test registry.name == "Foobar"
     end


### PR DESCRIPTION
## Resolves: #19 

Since this is a pre-1.0 package, I have no issues with not having a super-clean interface for somethings in exchange for the ability to more quickly add features and iterate over the package. When this package matures, cleaning this up will be more highly prioritized, but as this is currently just an off-hand utility package.

- Moved utility functions into `/src/utilities.jl`
- If there is a failure to find the UUID of a package by its string, output alternative packages which are closely named
- All `reachable_registry()` calls return an Array of instances, this simplifies things a lot more
- Fixed bug with `users()` would not allow you to look for usages of a package outside of `pkg_registry`. For example, if I wanted to look up all usages of `DataFrames` in an internal repository, I could not unless `DataFrames` was registered in the internal repository.
- Set the compat to `Julia1.6`