### PR TITLE
change test UUIDs to make more sense

### DIFF
--- a/test/resources/registries/Foobar/Registry.toml
+++ b/test/resources/registries/Foobar/Registry.toml
@@ -5,5 +5,5 @@ description = "Fake private package registry."
 
 [packages]
 00000000-1111-2222-3333-444444444444 = { name = "Case1", path = "Case1" }
-000eeb74-f857-587a-a816-be5685e97e75 = { name = "Case2", path = "Case2" }
-d5005c69-b073-4eb3-8b36-d4bd8a43d538 = { name = "DownDep", path = "DownDep" }
+a2a98da0-c97c-48ea-aa95-967bbb6a44f4 = { name = "Case2", path = "Case2" }
+000eeb74-f857-587a-a816-be5685e97e75 = { name = "DownDep", path = "DownDep" }

--- a/test/resources/registries/General/Case4/Deps.toml
+++ b/test/resources/registries/General/Case4/Deps.toml
@@ -1,2 +1,2 @@
 ["0-0.1"]
-DownDep = "d5005c69-b073-4eb3-8b36-d4bd8a43d538"
+DownDep = "000eeb74-f857-587a-a816-be5685e97e75"

--- a/test/resources/registries/General/Registry.toml
+++ b/test/resources/registries/General/Registry.toml
@@ -11,5 +11,5 @@ some amount of consideration when choosing package names.
 """
 
 [packages]
-000eeb74-f857-587a-a816-be5685e97e75 = { name = "Case3", path = "Case3" }
-001eeb74-f857-587a-a816-be5685e97e75 = { name = "Case4", path = "Case4" }
+40783f5b-986f-4943-913a-db8b00df110d = { name = "Case3", path = "Case3" }
+172f9e6e-38ba-42e1-abf1-05c2c32c0454 = { name = "Case4", path = "Case4" }


### PR DESCRIPTION
I started to revisit #16 (where I had actually started to implement UUID stuff locally) and saw what I think are some issues with the current UUID implementation. I figured I'd start with the tests here.

Currently, there are two UUIDs for DownDep:

* `000eeb74-f857-587a-a816-be5685e97e75`: used in `Foobar/Case1/Deps.toml`, `Foobar/Case2/Deps.toml`, `General/Case3/Deps.toml` to refer to DownDep, and in `General/Registry.toml` to refer to Case3, and in `Foobar/Registry.toml` to refer to Case2
* `d5005c69-b073-4eb3-8b36-d4bd8a43d538`: used in `Foobar/Registry.toml` and `General/Case4/Deps.toml` to refer to DownDep

This PR changes things so that `000eeb74-f857-587a-a816-be5685e97e75` is always used to refer to DownDep, and gives Case3 its own UUID, `40783f5b-986f-4943-913a-db8b00df110d`, and Case2 it's own UUID, namely `a2a98da0-c97c-48ea-aa95-967bbb6a44f4`. Lastly, I changed the UUID for Case4 from `001eeb74-f857-587a-a816-be5685e97e75` (which is not incorrect, just very similar to the DownDep uuid) to a new random one, `172f9e6e-38ba-42e1-abf1-05c2c32c0454`.

UUIDs were generated by `UUIDs.uuid4()`.

I also noticed DownDep is registered in FooBar registry but does not have a directory at the place indicated. I'm not sure if this is really a problem or not though.