### PR TITLE
add compat for Compat

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -11,6 +11,7 @@ TOML = "fa267f1f-6049-4f14-aa54-33bafae1ed76"
 UUIDs = "cf7118a7-6976-5b1a-9a39-7adc72f591a4"
 
 [compat]
+Compat = "3.26.0"
 TOML = "1.0"
 julia = "1.5"
 


### PR DESCRIPTION
Oops, forgot this. Here, I chose `3.26.0` as the first release that includes the functionality we need (but it is interpreted by the package resolver as any release semver-compatible with `3.26.0`, i.e. anything after that release and strictly before 4.0).