### PR TITLE
Support registries in gzipped tarballs

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -4,10 +4,12 @@ license = "MIT"
 version = "0.6.2"
 
 [deps]
+CodecZlib = "944b1d66-785c-5afd-91f1-9de20f533193"
 Compat = "34da2185-b29b-5c13-b0c7-acf172513d20"
 Pkg = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
 REPL = "3fa0cd96-eef1-5676-8a61-b3b8758bbffb"
 TOML = "fa267f1f-6049-4f14-aa54-33bafae1ed76"
+Tar = "a4e569a6-e804-4fa4-b0f3-eef7a1d5b13e"
 UUIDs = "cf7118a7-6976-5b1a-9a39-7adc72f591a4"
 
 [compat]


### PR DESCRIPTION
Starting with Julia 1.7, a registry can also be stored in a depot as a
gzipped tarball. This commit unpacks the tarball into a temporary
directory. This was the simplest way to support this new feature.

This implementation will unpack a fresh copy of the registry on every
call to `reachable_registries`. We could instead cache the temporary
directory for future calls.

There's an open PR for the Tar.jl package that will be of future
interest:

https://github.com/JuliaIO/Tar.jl/pull/95

This would allow us to instead stream the individual files straight
out of the tarball, rather than having to unpack it into a temporary
location.