### PR TITLE
Use the Pkg.Registry API

### DIFF
--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,6 +1,7 @@
 using PkgDeps
 using Test
 using UUIDs
+using Pkg
 
 const DEPOT = joinpath(@__DIR__, "resources")
 const GENERAL_REGISTRY = only(reachable_registries("General"; depots=DEPOT))
@@ -67,12 +68,23 @@ all_registries = reachable_registries(; depots=DEPOT)
         entry = PkgDeps._find_latest_pkg_entry("ClashPkg"; registries=all_registries)
         # General has a later version of `ClashPkg`
         @test entry.uuid == clashpkg_general_uuid
-        @test entry.repo == "https://path.to.repo/"
+
+        @static if VERSION >= v"1.7"
+            Pkg.Registry.init_package_info!(entry)
+            @test entry.info.repo == "https://path.to.repo/"
+        else
+            @test entry.repo == "https://path.to.repo/"
+        end
 
         # No conflict here, so it should just find the right one
         entry = PkgDeps._find_latest_pkg_entry("Case4"; registries=all_registries)
         @test entry.uuid == UUID("172f9e6e-38ba-42e1-abf1-05c2c32c0454")
-        @test entry.repo == "https://path.to.repo/"
+        @static if VERSION >= v"1.7"
+            Pkg.Registry.init_package_info!(entry)
+            @test entry.info.repo == "https://path.to.repo/"
+        else
+            @test entry.repo == "https://path.to.repo/"
+        end
 
         entry = PkgDeps._find_latest_pkg_entry(missing, UUID("172f9e6e-38ba-42e1-abf1-05c2c32c0454"); registries=all_registries)
         @test entry.name == "Case4"


### PR DESCRIPTION
As of Julia 1.7, Pkg.Registry provides some of the capability that had
been implemented in this package. This commit makes this package's
`reachable_registries` a simple wrapper around
`Pkg.Registry.reachable_registries` and removes the `RegistryInstance`
and `PkgEntry` types in favor of the types of the same name in
Pkg.Registry.

The largest change is that this package's version of
`RegistryInstance` stored a dictionary mapping package names to
`PkgEntry`s, but Pkg.Registry's version has a dictionary mapping
`UUID`s to `PkgEntry`s.

A benefit of using the `Pkg.Registry` API is that it already supports
both uncompressed registries as well as registries stored in
compressed tarballs. Thus, this fixes #37.