### PR TITLE
Fix lookup of stdlibs on Julia v1.8

### DIFF
--- a/src/PkgDeps.jl
+++ b/src/PkgDeps.jl
@@ -21,7 +21,16 @@ const GENERAL_REGISTRY = "General"
 
 # borrowed from <https://github.com/JuliaRegistries/RegistryTools.jl/blob/77cae9ef6a075e1d6ec1592bc3e166234d3f01c8/src/builtin_pkgs.jl>
 const stdlibs = isdefined(Pkg.Types, :stdlib) ? Pkg.Types.stdlib : Pkg.Types.stdlibs
-const STDLIBS = stdlibs()
+const STDLIBS = @static if VERSION >= v"1.8"
+    # As of v1.8, the dictionary that we get from Pkg maps the UUID of
+    # each standard library package to a (name, version) tuple.
+    Dict(uuid => name
+         for (uuid, (name, _)) in stdlibs())
+else
+    # In earlier versions, the dictionary maps the UUID of each
+    # standard library package to its name.
+    stdlibs()
+end
 
 
 """


### PR DESCRIPTION
With Julia v1.8, there were Pkg API changes that caused this package to break. In particular, our method of determining whether a package is part of the standard library now fails.

With older versions of Julia, `Pkg.Types.stdlibs()` returns a dictionary mapping `UUID`s to `String`s, which are just the package names. As of Julia v1.8, `Pkg.Types.stdlibs()` returns a dictionary mapping `UUID`s to `Tuple{String, Union{Nothing, VersionNumber}}`.

This commit reworks the dictionary returned by `Pkg.Types.stdlibs()` for Julia v1.8 and later, so that the rest of the existing code in this package will work without modification.

Fixes #41.